### PR TITLE
Trim trailing 'smp' from kernelrelease for RedHat in buildenv::kernel

### DIFF
--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -8,7 +8,8 @@ class buildenv::kernel {
 
   $package_name = $::osfamily ? {
     'Debian' => "linux-headers-${::kernelrelease}",
-    'RedHat' => "kernel-devel-${::kernelrelease}",
+    'RedHat' => regsubst(
+      "kernel-devel-${::kernelrelease}", '^(.+)(smp)?$', '\1'),
   }
 
   package { 'kernel-dev':


### PR DESCRIPTION
If current kernel is an SMP kernel, 2.6.9-103.ELsmp for example, then is tries to install kernel-devel-2.6.9-103.ELsmp. However the real package name is kernel-devel-2.6.9-103.EL, so we have to trim the trailing 'smp'.
