### PR TITLE
Add a package to build kernel module on Debian

### DIFF
--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -19,4 +19,18 @@ class buildenv::kernel {
     ensure => present,
     name   => $package_name,
   }
+
+  # other usefull packages with kernel
+  case $::operatingsystem {
+
+    Debian:  {
+      package{ 'module-assistant':
+        ensure => present,
+      }
+    }
+
+    default: {}
+
+  }
+
 }


### PR DESCRIPTION
This module is needed to compile kernel module on the openvmtools module.
I think it should be installed from buildenv::kernel.
